### PR TITLE
論理削除の実装

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -42,7 +42,6 @@ class WebhookController < ApplicationController
         exists_user_id = User.find_by(line_user_id: new_line_user_id)
         if exists_user_id then
           exists_user_id.update(is_blocked: false)
-          User.create(line_user_id: new_line_user_id, friend_registration_datetime: timestamp_datetime, is_blocked: false)
         else
           User.create(line_user_id: new_line_user_id, friend_registration_datetime: timestamp_datetime, is_blocked: false)
         end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -37,7 +37,15 @@ class WebhookController < ApplicationController
 
       when Line::Bot::Event::Follow
         timestamp_datetime = Time.at(event['timestamp']/1000)
-        User.create(line_user_id: event['source']['userId'], friend_registration_datetime: timestamp_datetime)
+
+        new_line_user_id = event['source']['userId']
+        exists_user_id = User.find_by(line_user_id: new_line_user_id)
+        if exists_user_id then
+          exists_user_id.update(is_blocked: false)
+          User.create(line_user_id: new_line_user_id, friend_registration_datetime: timestamp_datetime, is_blocked: false)
+        else
+          User.create(line_user_id: new_line_user_id, friend_registration_datetime: timestamp_datetime, is_blocked: false)
+        end
 
         message = {
           type: 'text',
@@ -45,8 +53,10 @@ class WebhookController < ApplicationController
         }
         client.reply_message(event['replyToken'], message)
       when Line::Bot::Event::Unfollow
-        user = User.find_by(line_user_id: event['source']['userId'])
-        user.destroy!
+
+        block_line_user_id = event['source']['userId']
+        user = User.find_by(line_user_id: block_line_user_id)
+        user.update(is_blocked: true )
       end
     }
     head :ok

--- a/db/migrate/20210818023159_create_users.rb
+++ b/db/migrate/20210818023159_create_users.rb
@@ -3,7 +3,7 @@ class CreateUsers < ActiveRecord::Migration[6.0]
     create_table :users do |t|
       t.string :line_user_id, null: false, index: { unique: true }
       t.datetime :friend_registration_datetime, null: false
-      t.boolean :is_blocked
+      t.boolean :is_blocked, default: false, null: false
     end
   end
 end

--- a/db/migrate/20210818023159_create_users.rb
+++ b/db/migrate/20210818023159_create_users.rb
@@ -3,6 +3,7 @@ class CreateUsers < ActiveRecord::Migration[6.0]
     create_table :users do |t|
       t.string :line_user_id, null: false, index: { unique: true }
       t.datetime :friend_registration_datetime, null: false
+      t.boolean :is_blocked
     end
   end
 end

--- a/db/migrate/20210818090904_add_is_blocked.rb
+++ b/db/migrate/20210818090904_add_is_blocked.rb
@@ -1,5 +1,0 @@
-class Users < ActiveRecord::Migration[6.0]
-  def change
-    add_column :users, :is_blocked, :boolean
-  end
-end

--- a/db/migrate/20210818090904_add_is_blocked.rb
+++ b/db/migrate/20210818090904_add_is_blocked.rb
@@ -1,0 +1,5 @@
+class Users < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :is_blocked, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2021_08_18_023159) do
   create_table "users", force: :cascade do |t|
     t.string "line_user_id", null: false
     t.datetime "friend_registration_datetime", null: false
-    t.boolean "is_blocked"
+    t.boolean "is_blocked", default: false, null: false
     t.index ["line_user_id"], name: "index_users_on_line_user_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_18_023159) do
+ActiveRecord::Schema.define(version: 2021_08_18_090904) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2021_08_18_023159) do
   create_table "users", force: :cascade do |t|
     t.string "line_user_id", null: false
     t.datetime "friend_registration_datetime", null: false
+    t.boolean "is_blocked"
     t.index ["line_user_id"], name: "index_users_on_line_user_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_18_090904) do
+ActiveRecord::Schema.define(version: 2021_08_18_023159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
## 実装の背景・目的(Why)
- LINE BOTをブロックした後にブロック解除した場合にも発行されたクーポン情報を引き継ぐため
    - そのまま削除してしまうと、クーポンは使えてしまうため、*クーポンを使ったのに来店情報が記録されない*ということが起こりうる

## 実装内容(How)
- userテーブルに`is_blocked`(boolean)カラムを追加しました。
- 友達登録時の挙動を変更しました
- 被ブロック時の挙動を変更しました

## やったこと(What)

- Userテーブルに`is_blocked`を追加するようにmigrationファイルを変更
- もしDBにデータが追加されていなければ、追加する
- 既にDBにデータが存在していれば、`is_blocked`をfalseに変更する。
- ブロックされた場合、データの`is_blocked`をtrueに変更する。


## 挙動確認

- サーバーを起動した状態で、LINEのBOTをブロックしたり解除したりしながらDBとログを確認してください。
