### PR TITLE
gajoenを叩くAPIの実装

### DIFF
--- a/app/models/gajoen_api.rb
+++ b/app/models/gajoen_api.rb
@@ -9,7 +9,7 @@ class GajoenApi
       :item_id => item_id,
       :request_code => request_code
     }
-    url = ENV['GAJOEN_URI']+ "/brands/#{brand_id}/tickets/"
+    url = ENV['GAJOEN_DOMAIN']+ "/brands/#{brand_id}/tickets/"
     uri = URI.parse(url)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true

--- a/app/models/gajoen_api.rb
+++ b/app/models/gajoen_api.rb
@@ -6,8 +6,8 @@ class GajoenApi
   def self.create_tickets(brand_id, item_id)
     request_code = SecureRandom.urlsafe_base64(30)
     query={
-      'item_id'=>item_id,
-      'request_code'=>request_code
+      :item_id => item_id,
+      :request_code => request_code
     }
     url = ENV['GAJOEN_URI']+ "/brands/#{brand_id}/tickets/"
     uri = URI.parse(url)
@@ -19,6 +19,7 @@ class GajoenApi
     req['X-Giftee'] = 1
     req.set_form_data(query)
     res = http.request(req)
+    p res
     case res
     when Net::HTTPSuccess
       return JSON.parse(res.body)

--- a/app/models/gajoen_api.rb
+++ b/app/models/gajoen_api.rb
@@ -15,7 +15,6 @@ class GajoenApi
     req['X-Giftee'] = 1
     req.set_form_data(query)
     res = http.request(req)
-    p res
     case res
     when Net::HTTPSuccess
       return JSON.parse(res.body)

--- a/app/models/gajoen_api.rb
+++ b/app/models/gajoen_api.rb
@@ -23,7 +23,7 @@ class GajoenApi
     when Net::HTTPSuccess
       return JSON.parse(res.body)
     else
-      return nil
+      raise
     end
   end
 end

--- a/app/models/gajoen_api.rb
+++ b/app/models/gajoen_api.rb
@@ -1,7 +1,3 @@
-require 'net/https'
-require 'uri'
-require 'securerandom'
-
 class GajoenApi
   def self.create_tickets(brand_id, item_id)
     request_code = SecureRandom.urlsafe_base64(30)

--- a/app/models/gajoen_api.rb
+++ b/app/models/gajoen_api.rb
@@ -1,0 +1,29 @@
+require 'net/https'
+require 'uri'
+require 'securerandom'
+
+class GajoenApi
+  def self.create_tickets(brand_id, item_id)
+    request_code = SecureRandom.urlsafe_base64(30)
+    query={
+      'item_id'=>item_id,
+      'request_code'=>request_code
+    }
+    url = ENV['GAJOEN_URI']+ "/brands/#{brand_id}/tickets/"
+    uri = URI.parse(url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    req = Net::HTTP::Post.new(uri.request_uri)
+    req['Authorization'] = ENV['GAJOEN_HEADER']
+    req['X-Giftee'] = 1
+    req.set_form_data(query)
+    res = http.request(req)
+    case res
+    when Net::HTTPSuccess
+      return JSON.parse(res.body)
+    else
+      return nil
+    end
+  end
+end


### PR DESCRIPTION
## 実装の背景・目的 (Why)

gajoen(チケット発行API)に問い合わせることにより、チケットを発行するため。将来的にはユーザーにそのURLを送信する。

## 実装内容 / やったこと (How / What)

- modelとしてgajoen_api.rbを発行するファイルを追加

## 補足

- [こちら](https://github.com/Calic0Cat/intern-line-bot/blob/master/app/services/gajoen_API.rb)を ~~パクリ~~ 参考にさせていただきました

## 疑問点
- 6行目 `def self.create_tickets`の引数が参考元だと末尾に`:`がついていますが、これはなんですか
