### PR TITLE
チケットテーブルの作成

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -46,6 +46,12 @@ class WebhookController < ApplicationController
           text: '友達登録ありがとうございます！'
         }
         client.reply_message(event['replyToken'], message)
+        begin
+          res = GajoenApi.create_tickets(145,56509)
+          Ticket.add(res['code'], res['brand_id'], res['item_id'], res['url'], res['status'], res['issued_at'], res['exchanged_at'], request_line_user_id)
+        rescue
+          raise
+        end
 
       when Line::Bot::Event::Unfollow
         User.find_by(line_user_id: event['source']['userId']).archive

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -40,18 +40,20 @@ class WebhookController < ApplicationController
         request_line_user_id = event['source']['userId']
 
         User.register(request_line_user_id, timestamp_datetime)
-
-        message = {
-          type: 'text',
-          text: '友達登録ありがとうございます！'
-        }
-        client.reply_message(event['replyToken'], message)
         begin
           res = GajoenApi.create_tickets(145,56509)
           Ticket.add(res['code'], res['brand_id'], res['item_id'], res['url'], res['status'], res['issued_at'], res['exchanged_at'], request_line_user_id)
+          message = {
+            type: 'text',
+            text: '友達登録ありがとうございます！感謝の気持ちを込めて、クーポンをお送りいたします。是非ご活用ください！' + res['url']
+          }
         rescue
-          raise
+          message = {
+            type: 'text',
+            text: '友達登録ありがとうございます！'
+          }
         end
+        client.reply_message(event['replyToken'], message)
 
       when Line::Bot::Event::Unfollow
         User.find_by(line_user_id: event['source']['userId']).archive

--- a/app/models/gajoen_api.rb
+++ b/app/models/gajoen_api.rb
@@ -23,7 +23,7 @@ class GajoenApi
     when Net::HTTPSuccess
       return JSON.parse(res.body)
     else
-      return nil
+      raise
     end
   end
 end

--- a/app/models/gajoen_api.rb
+++ b/app/models/gajoen_api.rb
@@ -1,0 +1,29 @@
+require 'net/https'
+require 'uri'
+require 'securerandom'
+
+class GajoenApi
+  def self.create_tickets(brand_id, item_id)
+    request_code = SecureRandom.urlsafe_base64(30)
+    query={
+      'item_id'=>item_id,
+      'request_code'=>request_code
+    }
+    url = ENV['GAJOEN_URI']+ "/brands/#{brand_id}/tickets/"
+    uri = URI.parse(url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    req = Net::HTTP::Post.new(uri.request_uri)
+    req['Authorization'] = ENV['GAJOEN_HEADER']
+    req['X-Giftee'] = 1
+    req.set_form_data(query)
+    res = http.request(req)
+    case res
+    when Net::HTTPSuccess
+      return JSON.parse(res.body)
+    else
+      return nil
+    end
+  end
+end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,7 +1,21 @@
 class Ticket < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, foreign_key: :line_user_id, optional: true
+  #userにnilを許容する
 
-  validates [:code, :url], uniqueness: true
-  validates [:code, :brand_id, :item_id, :url, :status, :issued_at, :line_user_id], presence: true
-  
+  validates :code, :url, uniqueness: true
+  validates :code, :brand_id, :item_id, :url, :status, :issued_at, :line_user_id, presence: true
+
+  def self.add(code, brand_id, item_id, url, status, issued_at, exchanged_at, line_user_id)
+    Ticket.new(
+      code: code,
+      brand_id: brand_id,
+      item_id: item_id,
+      url: url,
+      status: status,
+      issued_at: issued_at,
+      exchanged_at: exchanged_at,
+      line_user_id: line_user_id
+    ).save!
+
+  end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -6,7 +6,7 @@ class Ticket < ApplicationRecord
   validates :code, :brand_id, :item_id, :url, :status, :issued_at, :line_user_id, presence: true
 
   def self.add(code, brand_id, item_id, url, status, issued_at, exchanged_at, line_user_id)
-    Ticket.new(
+    self.create(
       code: code,
       brand_id: brand_id,
       item_id: item_id,
@@ -15,7 +15,7 @@ class Ticket < ApplicationRecord
       issued_at: issued_at,
       exchanged_at: exchanged_at,
       line_user_id: line_user_id
-    ).save!
+    )
 
   end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,0 +1,7 @@
+class Ticket < ApplicationRecord
+  belongs_to :user
+
+  validates [:code, :url], uniqueness: true
+  validates [:code, :brand_id, :item_id, :url, :status, :issued_at, :line_user_id], presence: true
+  
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :tickets
+
   validates :line_user_id, presence: true, uniqueness: true
   validates :friend_registration_datetime, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  has_many :tickets
+  has_many :tickets, foreign_key: :line_user_id
+  self.primary_key = :line_user_id
 
   validates :line_user_id, presence: true, uniqueness: true
   validates :friend_registration_datetime, presence: true

--- a/db/migrate/20210818023159_create_users.rb
+++ b/db/migrate/20210818023159_create_users.rb
@@ -1,7 +1,7 @@
 class CreateUsers < ActiveRecord::Migration[6.0]
   def change
-    create_table :users do |t|
-      t.string :line_user_id, null: false, index: { unique: true }
+    create_table :users, id: false do |t|
+      t.string :line_user_id, null: false, index: { unique: true }, primary_key: true
       t.datetime :friend_registration_datetime, null: false
       t.boolean :is_blocked, default: false, null: false
     end

--- a/db/migrate/20210819064555_create_tickets.rb
+++ b/db/migrate/20210819064555_create_tickets.rb
@@ -8,8 +8,8 @@ class CreateTickets < ActiveRecord::Migration[6.0]
       t.string :status, default: 'issued', null: false
       t.integer :issued_at, null: false
       t.integer :exchanged_at
-      t.references :user, null: false, foreign_key: true
-
+      t.string :line_user_id, null: false
     end
+    add_foreign_key :tickets, :users, column: :line_user_id, primary_key: "line_user_id"
   end
 end

--- a/db/migrate/20210819064555_create_tickets.rb
+++ b/db/migrate/20210819064555_create_tickets.rb
@@ -1,0 +1,15 @@
+class CreateTickets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tickets do |t|
+      t.string :code, null: false, index: { unique: true }
+      t.integer :brand_id, null: false
+      t.integer :item_id, null: false
+      t.string :url, null: false, index: { unique: true }
+      t.string :status, default: 'issued', null: false
+      t.integer :issued_at, null: false
+      t.integer :exchanged_at
+      t.references :user, null: false, foreign_key: true
+
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_18_023159) do
+ActiveRecord::Schema.define(version: 2021_08_19_064555) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "tickets", force: :cascade do |t|
+    t.string "code", null: false
+    t.integer "brand_id", null: false
+    t.integer "item_id", null: false
+    t.string "url", null: false
+    t.string "status", default: "issued", null: false
+    t.integer "issued_at", null: false
+    t.integer "exchanged_at"
+    t.bigint "user_id", null: false
+    t.index ["code"], name: "index_tickets_on_code", unique: true
+    t.index ["url"], name: "index_tickets_on_url", unique: true
+    t.index ["user_id"], name: "index_tickets_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "line_user_id", null: false
@@ -30,4 +44,5 @@ ActiveRecord::Schema.define(version: 2021_08_18_023159) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "tickets", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,14 +23,12 @@ ActiveRecord::Schema.define(version: 2021_08_19_064555) do
     t.string "status", default: "issued", null: false
     t.integer "issued_at", null: false
     t.integer "exchanged_at"
-    t.bigint "user_id", null: false
+    t.string "line_user_id", null: false
     t.index ["code"], name: "index_tickets_on_code", unique: true
     t.index ["url"], name: "index_tickets_on_url", unique: true
-    t.index ["user_id"], name: "index_tickets_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "line_user_id", null: false
+  create_table "users", primary_key: "line_user_id", id: :string, force: :cascade do |t|
     t.datetime "friend_registration_datetime", null: false
     t.boolean "is_blocked", default: false, null: false
     t.index ["line_user_id"], name: "index_users_on_line_user_id", unique: true
@@ -44,5 +42,5 @@ ActiveRecord::Schema.define(version: 2021_08_19_064555) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "tickets", "users"
+  add_foreign_key "tickets", "users", column: "line_user_id", primary_key: "line_user_id"
 end


### PR DESCRIPTION
## 実装の背景・目的 (Why)

チケットテーブルを作成し、データベースに問い合わせることで現在発行されているチケットを確認できるようにする

## 実装内容 / やったこと (How / What)

- Ticketテーブルの追加
- TicketテーブルとUserテーブルを:line_user_idをprimary_keyとしてbelongs_to / has_manyで結びつける
- 被友達登録時にgajoenに問い合わせてチケットを発行し、それをDBに保存する

## キャプチャ
![](https://user-images.githubusercontent.com/61941819/130163939-60cf39c3-29c8-49ef-a986-cbe430cf2f53.png)

## 補足

- 被友達登録時にチケットを発行しているが、現在ブロック解除と友達登録時を区別していないので、ブロック→ブロック解除で無限にチケットを発券できてしまう
    - DB内を確認して既にチケットが発券済みかどうかを調べる必要がある

## Next
- 任意のタイミングでのチケット送付（バッチ処理）及び次の来店チケット発行
